### PR TITLE
Normalise exit statuses

### DIFF
--- a/backup-apk.sh
+++ b/backup-apk.sh
@@ -13,7 +13,7 @@ ADB=${ADB-adb}
 if ! command -v "${ADB}" > /dev/null
 then
   echo "Missing required tool: ${ADB}"
-  exit 1
+  exit 2
 fi
 
 TMP_DIR=$(mktemp -d -t backup-apk.XXXXXXXXXX)

--- a/bundle-updates.sh
+++ b/bundle-updates.sh
@@ -5,13 +5,13 @@ set -eu
 if ! command -v bundle > /dev/null
 then
   echo "Missing required tool: bundle"
-  exit 1
+  exit 2
 fi
 
 if ! command -v git > /dev/null
 then
   echo "Missing required tool: git"
-  exit 1
+  exit 2
 fi
 
 GIT_MESSAGE_FILE=$(mktemp)

--- a/fetch-apple-event.sh
+++ b/fetch-apple-event.sh
@@ -11,13 +11,13 @@ fi
 if ! command -v curl > /dev/null
 then
   echo "Missing required tool: curl"
-  exit 1
+  exit 2
 fi
 
 if ! command -v ffmpeg > /dev/null
 then
   echo "Missing required tool: ffmpeg"
-  exit 1
+  exit 2
 fi
 
 SOURCE_PATH=$(pwd)

--- a/jks-to-crt-key.sh
+++ b/jks-to-crt-key.sh
@@ -11,13 +11,13 @@ fi
 if ! command -v keytool > /dev/null
 then
   echo "Missing required tool: keytool"
-  exit 1
+  exit 2
 fi
 
 if ! command -v openssl > /dev/null
 then
   echo "Missing required tool: openssl"
-  exit 1
+  exit 2
 fi
 
 SRCKEYSTORE=${1}

--- a/make-ca.sh
+++ b/make-ca.sh
@@ -11,7 +11,7 @@ fi
 if ! command -v openssl > /dev/null
 then
   echo "Missing required tool: openssl"
-  exit 1
+  exit 2
 fi
 
 CA_ROOT=${1}

--- a/mysql-root.sh
+++ b/mysql-root.sh
@@ -5,7 +5,7 @@ set -eu
 if ! command -v mysql > /dev/null
 then
   echo "Missing required tool: mysql"
-  exit 1
+  exit 2
 fi
 
 MYSQL_USER=debian-sys-maint

--- a/pkg-remove.sh
+++ b/pkg-remove.sh
@@ -11,7 +11,7 @@ fi
 if ! command -v pkgutil > /dev/null
 then
   echo "Missing required tool: pkgutil"
-  exit 1
+  exit 2
 fi
 
 pkgutil --pkg-info "${1}"

--- a/strip-jar.sh
+++ b/strip-jar.sh
@@ -11,13 +11,13 @@ fi
 if ! command -v unzip > /dev/null
 then
   echo "Missing required tool: unzip"
-  exit 3
+  exit 2
 fi
 
 if ! command -v jar > /dev/null
 then
   echo "Missing required tool: jar"
-  exit 3
+  exit 2
 fi
 
 UNZIP_DIR=$(mktemp -d -t $$.XXXXXXXXXX)

--- a/update-drupal.sh
+++ b/update-drupal.sh
@@ -5,7 +5,7 @@ set -eu
 if ! command -v drush > /dev/null
 then
   echo "Missing required tool: drush"
-  exit 1
+  exit 2
 fi
 
 drush ard

--- a/version-apk.sh
+++ b/version-apk.sh
@@ -11,7 +11,7 @@ fi
 if ! command -v apktool > /dev/null
 then
   echo "Missing required tool: apktool"
-  exit 1
+  exit 2
 fi
 
 while [ ${#} -gt 0 ]


### PR DESCRIPTION
Across the scripts, `exit 1` if the command arguments are invalid,
`exit 2` if a required tool is missing