### PR TITLE
Add `curl-benchmark.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Backup all APK files from an attached Android device.
 
 Run Bundle update in a Ruby project, determine the appropriate direct and transitive dependencies, and add a Git commit with a corresponding message.
 
+## Curl Benchmark
+
+    curl-benchmark.sh <curl-arguments>
+
+Execute a Curl request a number of times, reporting the total time spent on the request, for a loose benchmark of the request.
+
 ## Fetch Apple Event
 
     fetch-apple-event.sh <url> <quality>

--- a/curl-benchmark.sh
+++ b/curl-benchmark.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ ${#} -eq 0 ]
+then
+  echo "Usage ${0} <curl-arguments>"
+  exit 1
+fi
+
+if ! command -v curl > /dev/null
+then
+  echo "Missing required tool: curl"
+  exit 2
+fi
+
+for _ in $(seq 1 5)
+do
+  curl "${@}" \
+    --output /dev/null \
+    --silent \
+    --write-out 'time_total:  %{time_total}\n'
+done


### PR DESCRIPTION
Execute a Curl request a number of times, reporting the total time
spent on the request, for a loose benchmark of the request.