### PR TITLE
bundle-updates: work with older gits

### DIFF
--- a/bundle-updates.sh
+++ b/bundle-updates.sh
@@ -15,7 +15,7 @@ then
 fi
 
 GIT_MESSAGE_FILE=$(mktemp)
-GIT_CURRENT_BRANCH=$(git branch --show-current)
+GIT_CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 GIT_UPDATES_BRANCH=bundle-updates-$(date +%s)
 DIRECT=()
 TRANSITIVE=()


### PR DESCRIPTION
Remove use of `git branch --show-current` to allow use in git
before v2.22.0