### PR TITLE
Add `npm-updates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Make a local Certificate Authority using OpenSSL.
 
 Under Debian, Log into MySQL as the root user, using the specific maintainer user created at package install time.
 
+## NPM Updates
+
+    npm-updates.js
+
+Run NPM install in a NodeJS project after removing the existing lockfile, determine the appropriate direct and transitive dependencies, and add a Git commit with a corresponding message.
+
 ## Pkg Remove
 
     pkg-remove.sh <pkg-id>

--- a/npm-updates.js
+++ b/npm-updates.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const { appendFileSync, readFileSync, unlinkSync } = require('fs');
+
+function diff (before, after, output) {
+  for (const key in before) {
+    if (!(key in after)) {
+      output.removed[key] = before[key];
+      output.total[key] = before[key];
+      continue;
+    }
+
+    if (key in after && before[key] !== after[key]) {
+      output.modified[key] = after[key];
+      output.total[key] = after[key];
+    }
+    delete after[key];
+  }
+
+  for (const key in after) {
+    output.added[key] = after[key];
+    output.total[key] = after[key];
+  }
+}
+
+function exists (obj) {
+  return Object.entries(obj).length > 0;
+}
+
+function getDependencies () {
+  const pkg = JSON.parse(readFileSync('package.json'));
+  const pkgLock = JSON.parse(readFileSync('package-lock.json'));
+
+  const direct = Object.keys({
+    ...pkg.dependencies,
+    ...pkg.devDependencies
+  }).sort();
+
+  const transitive = Object.keys(pkgLock.dependencies).filter(d => !direct.includes(d));
+
+  const output = {
+    direct: {},
+    transitive: {}
+  };
+
+  direct.forEach((d) => {
+    output.direct[d] = pkgLock.dependencies[d].version;
+  });
+
+  transitive.forEach((d) => {
+    output.transitive[d] = pkgLock.dependencies[d].version;
+  });
+
+  return output;
+}
+
+function mktemp () {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let tmpFile = 'tmp.';
+  for (let i = 0; i < 8; i++) {
+    const index = Math.floor(Math.random() * chars.length);
+    tmpFile += chars[index];
+  }
+  return `${process.env.TMPDIR}${tmpFile}`;
+}
+
+function writeDependencies (file, message, dependencies, prefix = ' ') {
+  if (exists(dependencies)) {
+    appendFileSync(file, `${prefix}${message}\n\n`);
+    for (const [key, value] of Object.entries(dependencies)) {
+      appendFileSync(file, `${prefix} * ${key}: ${value}\n`);
+    }
+    appendFileSync(file, '\n');
+  }
+}
+
+const before = getDependencies();
+
+execSync('rm -rf node_modules package-lock.json', { stdio: 'inherit' });
+
+execSync('npm install', { stdio: 'inherit' });
+
+const after = getDependencies();
+
+const direct = {
+  added: {},
+  modified: {},
+  removed: {},
+  total: {}
+};
+
+const transitive = {
+  added: {},
+  modified: {},
+  removed: {},
+  total: {}
+};
+
+diff(before.direct, after.direct, direct);
+diff(before.transitive, after.transitive, transitive);
+
+if (exists(direct.total) || exists(transitive.total)) {
+  execSync(`git checkout -b npm-updates-${Date.now()}`, { stdio: 'inherit' });
+  execSync('git add package-lock.json', { stdio: 'inherit' });
+
+  const commitMessageFile = mktemp();
+  console.log(commitMessageFile);
+
+  appendFileSync(commitMessageFile, 'Dependency updates\n\n');
+
+  if (exists(direct.total)) {
+    appendFileSync(commitMessageFile, 'Direct dependencies\n\n');
+
+    writeDependencies(commitMessageFile, 'Added', direct.added);
+    writeDependencies(commitMessageFile, 'Removed', direct.removed);
+    writeDependencies(commitMessageFile, 'Modified', direct.modified);
+  }
+
+  if (exists(transitive.total)) {
+    appendFileSync(commitMessageFile, 'Transitive dependencies\n\n');
+
+    writeDependencies(commitMessageFile, 'Added', transitive.added);
+    writeDependencies(commitMessageFile, 'Removed', transitive.removed);
+    writeDependencies(commitMessageFile, 'Modified', transitive.modified);
+  }
+
+  execSync(`git commit --file ${commitMessageFile}`, { stdio: 'inherit' });
+  unlinkSync(commitMessageFile);
+}


### PR DESCRIPTION
Run NPM install in a NodeJS project after removing the existing
lockfile, determine the appropriate direct and transitive
dependencies, and add a Git commit with a corresponding message.